### PR TITLE
Potential fix for code scanning alert no. 6: Log entries created from user input

### DIFF
--- a/src/Identity.API/Quickstart/Consent/ConsentController.cs
+++ b/src/Identity.API/Quickstart/Consent/ConsentController.cs
@@ -156,7 +156,8 @@ public class ConsentController : Controller
         }
         else
         {
-            _logger.LogError("No consent request matching request: {0}", returnUrl);
+            var sanitizedReturnUrl = returnUrl.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            _logger.LogError("No consent request matching request: {0}", sanitizedReturnUrl);
         }
 
         return null;


### PR DESCRIPTION
Potential fix for [https://github.com/priyasalwan/eShop/security/code-scanning/6](https://github.com/priyasalwan/eShop/security/code-scanning/6)

To fix the problem, we need to sanitize the `returnUrl` before logging it. Since the log entries are plain text, we should remove any newline characters from the `returnUrl` to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
